### PR TITLE
Append unix timestamp to coinflip images to bypass caching

### DIFF
--- a/KfChatDotNetBot/Commands/Kasino/CoinflipCommand.cs
+++ b/KfChatDotNetBot/Commands/Kasino/CoinflipCommand.cs
@@ -103,7 +103,7 @@ public class CoinflipCommand : ICommand
             var coinflipAnimation = GetCoinFlipAnimationUrl(choiceStr);
 
             await botInstance.SendChatMessageAsync($"[IMG]{coinflipAnimation}[/IMG]", true, autoDeleteAfter: cleanupDelay);
-            await Task.Delay(1200, ctx);
+            await Task.Delay(1500, ctx);
 
             var effect = wager;
             newBalance = await Money.NewWagerAsync(gambler.Id, wager, effect, WagerGame.CoinFlip, ct: ctx);
@@ -119,7 +119,7 @@ public class CoinflipCommand : ICommand
             var coinflipAnimationURL = GetCoinFlipAnimationUrl("heads" == choiceStr ? "tails" : "heads", isJacky);
 
             await botInstance.SendChatMessageAsync($"[IMG]{coinflipAnimationURL}[/IMG]", true, autoDeleteAfter: cleanupDelay);
-            await Task.Delay(1200, ctx);
+            await Task.Delay(1500, ctx);
 
             newBalance = await Money.NewWagerAsync(gambler.Id, wager, -wager, WagerGame.CoinFlip, ct: ctx);
             await botInstance.SendChatMessageAsync(


### PR DESCRIPTION
I also extended the wait time a bit as it appeared to me like the win/lose message came in a bit too early.