### PR TITLE
Add tagging to image carousel

### DIFF
--- a/KfChatDotNetBot/Commands/ImageCommands.cs
+++ b/KfChatDotNetBot/Commands/ImageCommands.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http.Headers;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Humanizer;
 using KfChatDotNetBot.Extensions;
@@ -15,10 +16,10 @@ namespace KfChatDotNetBot.Commands;
 public class AddImageCommand : ICommand
 {
     public List<Regex> Patterns => [
-        new Regex(@"^admin image (?<key>\w+) add (?<url>.+)$"),
-        new Regex(@"^admin images (?<key>\w+) add (?<url>.+)$"),
-        new Regex(@"^admin image (?<key>\w+) add_nigger (?<url>.+)$"),
-        new Regex(@"^admin images (?<key>\w+) add_nigger (?<url>.+)$")
+        new Regex(@"^admin image (?<key>\w+) add (?<url>\S+)(?:\s+(?<raw>raw))?(?:\s+(?<tags>.+))?$"),
+        new Regex(@"^admin images (?<key>\w+) add (?<url>\S+)(?:\s+(?<raw>raw))?(?:\s+(?<tags>.+))?$"),
+        new Regex(@"^admin image (?<key>\w+) add_nigger (?<url>\S+)(?:\s+(?<raw>raw))?(?:\s+(?<tags>.+))?$"),
+        new Regex(@"^admin images (?<key>\w+) add_nigger (?<url>\S+)(?:\s+(?<raw>raw))?(?:\s+(?<tags>.+))?$")
     ];
     public string? HelpText => "Add an image to the image rotation specified";
     public UserRight RequiredRight => UserRight.TrueAndHonest;
@@ -33,7 +34,9 @@ public class AddImageCommand : ICommand
         if (imageKeys == null) throw new InvalidOperationException($"{BuiltIn.Keys.BotImageAcceptableKeys} was null");
         var key = arguments["key"].Value;
         var url = arguments["url"].Value;
+        var tags = arguments["tags"].Success ? arguments["tags"].Value.Trim() : null;
         var niggerMode = message.Message.Contains("add_nigger");
+        var _rawMode = arguments["raw"].Success;
         if (!imageKeys.Contains(key))
         {
             await botInstance.SendChatMessageAsync(
@@ -47,9 +50,17 @@ public class AddImageCommand : ICommand
             return;
         }
 
-        await db.Images.AddAsync(new ImageDbModel { Key = key, Url = url, LastSeen = DateTimeOffset.MinValue }, ctx);
+        if (!Regex.IsMatch(url, @"^https?://\S+$"))
+        {
+            await botInstance.SendWhisperAsync(user.KfId, $"The URL '{url}' you provided is not valid");
+            return;
+        }
+
+        string result = url;
+        // todo add automatic compression/re-upload and raw mode option
+
+        await db.Images.AddAsync(new ImageDbModel { Key = key, Url = result, LastSeen = DateTimeOffset.MinValue, Tags = tags }, ctx);
         await db.SaveChangesAsync(ctx);
-        //await botInstance.SendChatMessageAsync("Added image to database", true);
         await botInstance.SendChatMessageAsync(
             $"{user.FormatUsername()}, you added the following media to the {key} carousel\n[img]{url}[/img]", true);
     }
@@ -130,7 +141,9 @@ public class ListImageCommand : ICommand
             var content = string.Empty;
             foreach (var image in images)
             {
-                content += image.Url + Environment.NewLine;
+                var ts = DateTimeOffset.UtcNow - image.LastSeen;
+                var time = $"{ts.TotalDays:N0}d{ts.Hours:N0}h{ts.Minutes:N0}m{ts.Seconds:N0}s";
+                content += $"{image.Url} - {time} - {image.Tags}" + Environment.NewLine;
             }
 
             var paste = await Zipline.Upload(content, new MediaTypeHeaderValue("text/plain"), "1d", ctx);
@@ -152,11 +165,62 @@ public class ListImageCommand : ICommand
     }
 }
 
+public class ManageImageKeyCommand : ICommand
+{
+    public List<Regex> Patterns => [
+        new Regex(@"^admin imagekey add (?<key>\w+)$"),
+        new Regex(@"^admin imagekey remove (?<key>\w+)$"),
+        new Regex(@"^admin imagekey delete (?<key>\w+)$"),
+        new Regex(@"^admin imageskey add (?<key>\w+)$"),
+        new Regex(@"^admin imageskey remove (?<key>\w+)$"),
+        new Regex(@"^admin imageskey delete (?<key>\w+)$")
+    ];
+    public string? HelpText => "Add or remove an acceptable image key from the BotImageAcceptableKeys setting";
+    public UserRight RequiredRight => UserRight.Admin;
+    public TimeSpan Timeout => TimeSpan.FromSeconds(10);
+    public RateLimitOptionsModel? RateLimitOptions => null;
+    public bool WhisperCanInvoke => false;
+    public async Task RunCommand(ChatBot botInstance, BotCommandMessageModel message, UserDbModel user, GroupCollection arguments,
+        CancellationToken ctx)
+    {
+        var imageKeys = (await SettingsProvider.GetValueAsync(BuiltIn.Keys.BotImageAcceptableKeys)).JsonDeserialize<List<string>>();
+        if (imageKeys == null) throw new InvalidOperationException($"{BuiltIn.Keys.BotImageAcceptableKeys} was null");
+        var key = arguments["key"].Value.ToLower();
+        var isAdd = message.Message.Contains(" add ");
+
+        if (isAdd)
+        {
+            if (imageKeys.Contains(key))
+            {
+                await botInstance.SendChatMessageAsync($"Key \"{key}\" is already in the acceptable keys list", true);
+                return;
+            }
+            imageKeys.Add(key);
+            await SettingsProvider.SetValueAsync(BuiltIn.Keys.BotImageAcceptableKeys, JsonSerializer.Serialize(imageKeys));
+            await botInstance.SendChatMessageAsync(
+                $"Added key \"{key}\" to acceptable image keys. Current keys: {string.Join(' ', imageKeys)}", true);
+        }
+        else
+        {
+            if (!imageKeys.Contains(key))
+            {
+                await botInstance.SendChatMessageAsync(
+                    $"Key \"{key}\" is not in the acceptable keys list. Current keys: {string.Join(' ', imageKeys)}", true);
+                return;
+            }
+            imageKeys.Remove(key);
+            await SettingsProvider.SetValueAsync(BuiltIn.Keys.BotImageAcceptableKeys, JsonSerializer.Serialize(imageKeys));
+            await botInstance.SendChatMessageAsync(
+                $"Removed key \"{key}\" from acceptable image keys. Current keys: {string.Join(' ', imageKeys)}", true);
+        }
+    }
+}
+
 [AllowAdditionalMatches]
 public class GetRandomImage : ICommand
 {
     public List<Regex> Patterns => [
-        new Regex(@"^(?<key>\w+)")
+        new Regex(@"^(?<key>\w+)(?:\s+(?<search>.+))?")
     ];
     public string? HelpText => "Get a random image";
     public UserRight RequiredRight => UserRight.Loser;
@@ -173,6 +237,7 @@ public class GetRandomImage : ICommand
     {
         await using var db = new ApplicationDbContext();
         var key = arguments["key"].Value.ToLower();
+        var searchTerm = arguments["search"].Success ? arguments["search"].Value.Trim() : null;
         var images = db.Images.Where(i => i.Key == key);
         if (!await images.AnyAsync(ctx))
         {
@@ -191,18 +256,41 @@ public class GetRandomImage : ICommand
             BuiltIn.Keys.BotImagePigCubeSelfDestructMax, BuiltIn.Keys.BotImageInvertedPigCubeSelfDestructDelay,
             BuiltIn.Keys.BotImageChinkSelfDestruct, BuiltIn.Keys.BotImageChinkSelfDestructDelay
         ]);
-        var divideBy = settings[BuiltIn.Keys.BotImageRandomSliceDivideBy].ToType<int>();
-        var limit = 1;
-        var count = await images.CountAsync(ctx);
-        if (count > divideBy)
-        {
-            limit = count / divideBy;
-        }
 
-        // EF with SQLite can't sort on dates as it's just TEXT
-        var selection = (await images.ToListAsync(ctx)).OrderBy(i => i.LastSeen).Take(limit).ToList();
-        // MaxValue is never returned by Next so you don't need to -1 for indexing
-        var image = selection[new Random().Next(0, selection.Count)];
+        ImageDbModel image;
+        if (!string.IsNullOrEmpty(searchTerm))
+        {
+            var allImages = await images.ToListAsync(ctx);
+            var searchTokens = searchTerm.ToLower().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var matches = allImages.Where(i =>
+            {
+                if (i.Tags == null) return false;
+                var tagTokens = i.Tags.ToLower().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                return searchTokens.All(st => tagTokens.Contains(st));
+            }).ToList();
+            if (matches.Count == 0)
+            {
+                RateLimitService.RemoveMostRecentEntry(user, this);
+                await botInstance.SendChatMessageAsync($"No image in {key} matched \"{searchTerm}\"", true);
+                return;
+            }
+            image = matches.OrderBy(i => i.LastSeen).First();
+        }
+        else
+        {
+            var divideBy = settings[BuiltIn.Keys.BotImageRandomSliceDivideBy].ToType<int>();
+            var limit = 1;
+            var count = await images.CountAsync(ctx);
+            if (count > divideBy)
+            {
+                limit = count / divideBy;
+            }
+
+            // EF with SQLite can't sort on dates as it's just TEXT
+            var selection = (await images.ToListAsync(ctx)).OrderBy(i => i.LastSeen).Take(limit).ToList();
+            // MaxValue is never returned by Next so you don't need to -1 for indexing
+            image = selection[new Random().Next(0, selection.Count)];
+        }
         image.LastSeen = DateTimeOffset.UtcNow;
         db.Images.Update(image);
         await db.SaveChangesAsync(ctx);

--- a/KfChatDotNetBot/Migrations/20260510073657_AddImageTags.Designer.cs
+++ b/KfChatDotNetBot/Migrations/20260510073657_AddImageTags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using KfChatDotNetBot;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,12 +11,14 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace KfChatDotNetBot.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510073657_AddImageTags")]
+    partial class AddImageTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "9.0.4");
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.3");
 
             modelBuilder.Entity("KfChatDotNetBot.Models.DbModels.ChipsggBetDbModel", b =>
                 {

--- a/KfChatDotNetBot/Migrations/20260510073657_AddImageTags.cs
+++ b/KfChatDotNetBot/Migrations/20260510073657_AddImageTags.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace KfChatDotNetBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddImageTags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Tags",
+                table: "Images",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Tags",
+                table: "Images");
+        }
+    }
+}

--- a/KfChatDotNetBot/Models/DbModels/ImageDbModel.cs
+++ b/KfChatDotNetBot/Models/DbModels/ImageDbModel.cs
@@ -6,4 +6,5 @@ public class ImageDbModel
     public required string Key { get; set; }
     public required string Url { get; set; }
     public required DateTimeOffset LastSeen { get; set; }
+    public string? Tags { get; set; }
 }


### PR DESCRIPTION
This adds two arguments to the `admin image <key> add` command, so the format is now `admin image <key> add <url> [raw] [tag1] [tag2] [tag3] ...`

- `raw` is optional and unused for now, the fork downloads, compresses and re-uploads images currently and using `raw` skips that step
- anything appended at the end is considered as image tags, currently they are space separated, so tags cannot have spaces

It also adds `admin imagekey add` and `admin imagekey remove` to add or remove image lists because I'm too lazy to edit the database for it.

As for importing existing tags, I haven't thought about that, yet.